### PR TITLE
Require 'some' bounds compatible with dependent-sum

### DIFF
--- a/reflex-gadt-api.cabal
+++ b/reflex-gadt-api.cabal
@@ -32,7 +32,7 @@ library
     , jsaddle             >=0.9.7  && <0.10
     , reflex              >=0.7    && <0.9
     , reflex-dom-core     >=0.6.0  && <0.7
-    , some                >=1      && <1.1
+    , some                >=1      && <1.0.3
     , text                >=1.2    && <1.3
     , time                >=1.6.0  && <2
 


### PR DESCRIPTION
See also https://github.com/obsidiansystems/dependent-sum/pull/58

Currently, trying to build with `some-1.0.3` makes cabal go all the way back to `dependent-sum-0.6.2.0`, which did not depend on `some` and had its own version until [0.6.2.1](https://github.com/obsidiansystems/dependent-sum/blob/master/dependent-sum/ChangeLog.md#0621---2020-03-21).
This is causing CI failures since it makes `deriveJSONGADT` supply instances for the wrong `Some`: 

```
instance FromJSON Text => FromJSON (dependent-sum-0.6.2.0:Data.Some.Some CatApi) where
```
```
Readme.lhs:151:23: error:
    • Could not deduce (FromJSON (some-1.0.3:Data.Some.Newtype.Some CatApi
```

